### PR TITLE
Уточнение: string_view ссылается на AuthorContainer

### DIFF
--- a/include/book.hpp
+++ b/include/book.hpp
@@ -16,7 +16,7 @@ constexpr Genre GenreFromString(std::string_view s) {
 }
 
 struct Book {
-    // string_view для экономии памяти, чтобы ссылаться на оригинальную строку, хранящуюся в другом контейнере
+    // string_view для экономии памяти, чтобы ссылаться на оригинальную строку, хранящуюся в контейнере BookDatabase::AuthorContainer
     std::string_view author;
     std::string title;
 


### PR DESCRIPTION
Корректируем расплывчатое "другой контейнер" в комментарии Book, явно указывая BookDatabase::AuthorContainer как источник строк